### PR TITLE
Add node-mocks-http for mock HTTP request and response in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
         "watch": "nodemon --watch server.js --watch src"
     },
     "keywords": [],
-    "author":
-        "Marc Littlemore <marc.littlemore@gmail.com> (http://www.marclittlemore.com)",
+    "author": "Marc Littlemore <marc.littlemore@gmail.com> (http://www.marclittlemore.com)",
     "license": "MIT",
     "dependencies": {
         "apac": "^3.0.2",
@@ -42,6 +41,7 @@
         "husky": "^0.14.3",
         "localtunnel": "^1.8.3",
         "mocha": "^4.0.1",
+        "node-mocks-http": "^1.6.6",
         "nodemon": "^1.12.1",
         "sinon": "^4.0.2",
         "sinon-chai": "^2.14.0"

--- a/test/unit/middleware/amazon/itemFilter.test.js
+++ b/test/unit/middleware/amazon/itemFilter.test.js
@@ -1,3 +1,4 @@
+import httpMocks from 'node-mocks-http';
 import itemFilter from '../../../../src/middleware/amazon/itemFilter';
 import * as amazonItemFilter from '../../../../src/services/amazonPrivateApi';
 import * as amazonApi from '../../../../src/services/amazon';
@@ -14,13 +15,9 @@ describe('Amazon itemFilter', () => {
     };
 
     beforeEach(() => {
-        // TODO : Use fake http request when I've got wifi!
-        fakeRequest = {query: {}};
-        fakeResponse = {
-            json: () => {},
-            locals: {},
-            status: () => {}
-        };
+        fakeRequest = httpMocks.createRequest();
+        fakeResponse = httpMocks.createResponse();
+        fakeResponse.locals = {};
 
         spyNext = sinon.spy();
         stubAmazonItemFilter = sinon

--- a/test/unit/middleware/amazon/responses.test.js
+++ b/test/unit/middleware/amazon/responses.test.js
@@ -1,3 +1,4 @@
+import httpMocks from 'node-mocks-http';
 import {
     apiFailure,
     apiSuccess
@@ -9,12 +10,8 @@ describe('Amazon responses', () => {
     let stubResponseJson;
 
     beforeEach(() => {
-        // TODO : Use fake http response when I've got wifi!
-        fakeResponse = {
-            json: () => {},
-            locals: {},
-            status: () => {}
-        };
+        fakeResponse = httpMocks.createResponse();
+        fakeResponse.locals = {};
 
         stubResponseJson = sinon.stub(fakeResponse, 'json');
     });

--- a/test/unit/middleware/defaultErrorHandler.test.js
+++ b/test/unit/middleware/defaultErrorHandler.test.js
@@ -1,3 +1,4 @@
+import httpMocks from 'node-mocks-http';
 import defaultErrorHandler from '../../../src/middleware/defaultErrorHandler';
 import notFound from '../../../src/botResponses';
 
@@ -10,13 +11,9 @@ describe('defaultErrorHandler', () => {
     const defaultError = new Error('defaultError');
 
     beforeEach(() => {
-        // TODO : Use fake http request when I've got wifi!
-        fakeRequest = {query: {}};
-        fakeResponse = {
-            json: () => {},
-            locals: {},
-            status: () => {}
-        };
+        fakeRequest = httpMocks.createRequest();
+        fakeResponse = httpMocks.createResponse();
+        fakeResponse.locals = {};
 
         stubResponseJson = sinon.stub(fakeResponse, 'json');
         stubResponseStatus = sinon

--- a/test/unit/middleware/determineAmazonLocale.test.js
+++ b/test/unit/middleware/determineAmazonLocale.test.js
@@ -1,3 +1,4 @@
+import httpMocks from 'node-mocks-http';
 import determineAmazonLocale from '../../../src/middleware/determineAmazonLocale';
 
 describe('determineAmazonLocale', () => {
@@ -6,9 +7,9 @@ describe('determineAmazonLocale', () => {
     let spyNext;
 
     beforeEach(() => {
-        // TODO : Use fake http request when I've got wifi!
-        fakeRequest = {query: {}};
-        fakeResponse = {locals: {}};
+        fakeRequest = httpMocks.createRequest();
+        fakeResponse = httpMocks.createResponse();
+        fakeResponse.locals = {};
         spyNext = sinon.spy();
     });
 

--- a/test/unit/middleware/notFoundHandler.test.js
+++ b/test/unit/middleware/notFoundHandler.test.js
@@ -1,3 +1,4 @@
+import httpMocks from 'node-mocks-http';
 import notFoundHandler from '../../../src/middleware/notFoundHandler';
 import notFound from '../../../src/botResponses';
 
@@ -8,13 +9,9 @@ describe('notFoundHandler', () => {
     let stubResponseStatus;
 
     beforeEach(() => {
-        // TODO : Use fake http request when I've got wifi!
-        fakeRequest = {query: {}};
-        fakeResponse = {
-            json: () => {},
-            locals: {},
-            status: () => {}
-        };
+        fakeRequest = httpMocks.createRequest();
+        fakeResponse = httpMocks.createResponse();
+        fakeResponse.locals = {};
 
         stubResponseJson = sinon.stub(fakeResponse, 'json');
         stubResponseStatus = sinon

--- a/test/unit/middleware/requestInformation.test.js
+++ b/test/unit/middleware/requestInformation.test.js
@@ -1,3 +1,4 @@
+import httpMocks from 'node-mocks-http';
 import requestInformation from '../../../src/middleware/requestInformation';
 
 describe('requestInformation', () => {
@@ -9,12 +10,13 @@ describe('requestInformation', () => {
     const defaultHostname = 'defaulthostname.com';
 
     beforeEach(() => {
-        // TODO : Use fake http request when I've got wifi!
-        fakeRequest = {
-            query: {},
-            protocol: defaultProtocol,
-            hostname: defaultHostname
-        };
+        fakeRequest = httpMocks.createRequest();
+        fakeRequest.protocol = defaultProtocol;
+        fakeRequest.hostname = defaultHostname;
+
+        fakeResponse = httpMocks.createResponse();
+        fakeResponse.locals = {};
+
         fakeResponse = {locals: {}};
         spyNext = sinon.spy();
     });

--- a/test/unit/middleware/validateApiKey.test.js
+++ b/test/unit/middleware/validateApiKey.test.js
@@ -1,3 +1,4 @@
+import httpMocks from 'node-mocks-http';
 import validateApiKey from '../../../src/middleware/validateApiKey';
 
 describe('validateApiKey', () => {
@@ -9,13 +10,9 @@ describe('validateApiKey', () => {
     let originalApiKey;
 
     beforeEach(() => {
-        // TODO : Use fake http request when I've got wifi!
-        fakeRequest = {query: {}};
-        fakeResponse = {
-            json: () => {},
-            locals: {},
-            status: () => {}
-        };
+        fakeRequest = httpMocks.createRequest();
+        fakeResponse = httpMocks.createResponse();
+        fakeResponse.locals = {};
 
         stubResponseJson = sinon.stub(fakeResponse, 'json');
         stubResponseStatus = sinon

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,7 +6,7 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
-accepts@~1.3.4:
+accepts@^1.3.3, accepts@~1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.4.tgz#86246758c7dd6d21a6474ff084a4740ec05eb21f"
   dependencies:
@@ -1073,7 +1073,7 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
-depd@1.1.1, depd@~1.1.1:
+depd@1.1.1, depd@^1.1.0, depd@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
 
@@ -1509,7 +1509,7 @@ forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
 
-fresh@0.5.2:
+fresh@0.5.2, fresh@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
 
@@ -2241,11 +2241,11 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
-merge-descriptors@1.0.1:
+merge-descriptors@1.0.1, merge-descriptors@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
 
-methods@~1.1.2:
+methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
@@ -2277,7 +2277,7 @@ mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.17, 
   dependencies:
     mime-db "~1.30.0"
 
-mime@1.4.1:
+mime@1.4.1, mime@^1.3.4:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
 
@@ -2350,6 +2350,10 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
+net@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/net/-/net-1.0.2.tgz#d1757ec9a7fb2371d83cf4755ce3e27e10829388"
+
 nise@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/nise/-/nise-1.2.0.tgz#079d6cadbbcb12ba30e38f1c999f36ad4d6baa53"
@@ -2366,6 +2370,21 @@ node-cache@^4.1.1:
   dependencies:
     clone "2.x"
     lodash "4.x"
+
+node-mocks-http@^1.6.6:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/node-mocks-http/-/node-mocks-http-1.6.6.tgz#0fdeef866cc122a80051bbd89a876d3c4cd21e13"
+  dependencies:
+    accepts "^1.3.3"
+    depd "^1.1.0"
+    fresh "^0.5.2"
+    merge-descriptors "^1.0.1"
+    methods "^1.1.2"
+    mime "^1.3.4"
+    net "^1.0.2"
+    parseurl "^1.3.1"
+    range-parser "^1.2.0"
+    type-is "^1.6.14"
 
 node-pre-gyp@^0.6.36:
   version "0.6.38"
@@ -2559,7 +2578,7 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
-parseurl@~1.3.2:
+parseurl@^1.3.1, parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
 
@@ -2719,7 +2738,7 @@ randomatic@^1.1.3:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-range-parser@~1.2.0:
+range-parser@^1.2.0, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
@@ -3323,7 +3342,7 @@ type-detect@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
-type-is@~1.6.15:
+type-is@^1.6.14, type-is@~1.6.15:
   version "1.6.15"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.15.tgz#cab10fb4909e441c82842eafe1ad646c81804410"
   dependencies:


### PR DESCRIPTION
Fix up tests now that I'm not on a train and have an internet connection!
Use `node-mocks-http` to mock HTTP request and response in tests.